### PR TITLE
Extend sport support

### DIFF
--- a/backend/src/__tests__/setup.ts
+++ b/backend/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+export {}; // empty setup for jest

--- a/backend/src/models/Event.ts
+++ b/backend/src/models/Event.ts
@@ -3,7 +3,17 @@ import mongoose, { Document, Schema } from 'mongoose';
 export interface IEvent extends Document {
   externalId: string; // TheSportsDB event ID
   eventName: string;
-  organization: 'UFC' | 'Bellator' | 'ONE' | 'PFL' | 'Boxing' | 'Other';
+  organization:
+    | 'UFC'
+    | 'Bellator'
+    | 'ONE'
+    | 'PFL'
+    | 'Boxing'
+    | 'NFL'
+    | 'NBA'
+    | 'MLB'
+    | 'Soccer'
+    | 'Other';
   eventDate: Date;
   venue: string;
   location: string;
@@ -72,7 +82,18 @@ const eventSchema = new Schema<IEvent>({
   },
   organization: {
     type: String,
-    enum: ['UFC', 'Bellator', 'ONE', 'PFL', 'Boxing', 'Other'],
+    enum: [
+      'UFC',
+      'Bellator',
+      'ONE',
+      'PFL',
+      'Boxing',
+      'NFL',
+      'NBA',
+      'MLB',
+      'Soccer',
+      'Other'
+    ],
     required: true
   },
   eventDate: {

--- a/backend/src/models/Pick.ts
+++ b/backend/src/models/Pick.ts
@@ -71,7 +71,18 @@ const pickSchema = new Schema<IPick>(
       organization: {
         type: String,
         required: true,
-        enum: ['UFC', 'Bellator', 'ONE', 'PFL', 'Boxing', 'Other']
+        enum: [
+          'UFC',
+          'Bellator',
+          'ONE',
+          'PFL',
+          'Boxing',
+          'NFL',
+          'NBA',
+          'MLB',
+          'Soccer',
+          'Other'
+        ]
       }
     },
     prediction: {

--- a/backend/src/routes/pick.routes.ts
+++ b/backend/src/routes/pick.routes.ts
@@ -19,7 +19,18 @@ const pickValidation = [
   body('fightEvent.eventName').notEmpty().withMessage('Event name is required'),
   body('fightEvent.date').isISO8601().withMessage('Valid date is required'),
   body('fightEvent.fighters').isArray({ min: 2, max: 2 }).withMessage('Exactly 2 fighters required'),
-  body('fightEvent.organization').isIn(['UFC', 'Bellator', 'ONE', 'PFL', 'Boxing', 'Other']),
+  body('fightEvent.organization').isIn([
+    'UFC',
+    'Bellator',
+    'ONE',
+    'PFL',
+    'Boxing',
+    'NFL',
+    'NBA',
+    'MLB',
+    'Soccer',
+    'Other'
+  ]),
   body('prediction.winner').notEmpty().withMessage('Winner prediction is required'),
   body('prediction.confidence').isInt({ min: 1, max: 10 }).withMessage('Confidence must be 1-10'),
   body('analysis').optional().isLength({ max: 2000 })

--- a/backend/src/services/multiSportsData.service.ts
+++ b/backend/src/services/multiSportsData.service.ts
@@ -1,0 +1,114 @@
+import axios from 'axios';
+import Event, { IEvent } from '../models/Event';
+
+export interface SportConfig {
+  key: string;          // Odds API sport key
+  organization: IEvent['organization'];
+}
+
+/**
+ * Service that can fetch events for multiple sports and keep a simple
+ * in-memory cache for quick access. This extends the existing
+ * SportsDataService which was MMA specific.
+ */
+export class MultiSportsDataService {
+  private apiKey: string;
+  private baseUrl: string;
+  private sports: SportConfig[];
+  private cache: Map<string, IEvent[]> = new Map();
+
+  constructor(sports?: SportConfig[]) {
+    this.apiKey = process.env.ODDS_API_KEY || '';
+    this.baseUrl = process.env.ODDS_API_BASE_URL || 'https://api.the-odds-api.com/v4';
+    // Default to a small selection of popular sports
+    this.sports =
+      sports || [
+        { key: 'mma_mixed_martial_arts', organization: 'UFC' },
+        { key: 'americanfootball_nfl', organization: 'NFL' },
+        { key: 'basketball_nba', organization: 'NBA' },
+        { key: 'baseball_mlb', organization: 'MLB' },
+        { key: 'soccer_epl', organization: 'Soccer' }
+      ];
+  }
+
+  /** Fetch events for all configured sports and populate the cache. */
+  async fetchAllUpcoming(): Promise<Map<string, IEvent[]>> {
+    const results = new Map<string, IEvent[]>();
+    for (const sport of this.sports) {
+      const events = await this.fetchSportEvents(sport);
+      results.set(sport.organization, events);
+      this.cache.set(sport.organization, events);
+    }
+    return results;
+  }
+
+  /** Retrieve cached events for a specific organization. */
+  getCached(organization: string): IEvent[] | undefined {
+    return this.cache.get(organization);
+  }
+
+  private async fetchSportEvents(sport: SportConfig): Promise<IEvent[]> {
+    try {
+      const res = await axios.get(`${this.baseUrl}/sports/${sport.key}/events`, {
+        params: {
+          apiKey: this.apiKey,
+          regions: 'us',
+          markets: 'h2h',
+          oddsFormat: 'american',
+          dateFormat: 'iso'
+        }
+      });
+
+      const oddsEvents: any[] = res.data;
+      const events: IEvent[] = [];
+
+      for (const oe of oddsEvents) {
+        const fighters = [oe.home_team, oe.away_team];
+        // Attempt to get odds from first bookmaker if present
+        let fighter1Odds = -110;
+        let fighter2Odds = -110;
+
+        if (oe.bookmakers && oe.bookmakers.length > 0) {
+          const bookmaker = oe.bookmakers[0];
+          const market = bookmaker.markets?.find((m: any) => m.key === 'h2h');
+          if (market && market.outcomes.length >= 2) {
+            const out1 = market.outcomes.find((o: any) => o.name === fighters[0]);
+            const out2 = market.outcomes.find((o: any) => o.name === fighters[1]);
+            if (out1) fighter1Odds = out1.price;
+            if (out2) fighter2Odds = out2.price;
+          }
+        }
+
+        const eventData = {
+          externalId: oe.id,
+          eventName: `${fighters[0]} vs ${fighters[1]}`,
+          organization: sport.organization,
+          eventDate: new Date(oe.commence_time),
+          venue: 'TBA',
+          location: 'TBA',
+          fights: [
+            {
+              fighter1: { name: fighters[0], odds: fighter1Odds },
+              fighter2: { name: fighters[1], odds: fighter2Odds },
+              scheduledRounds: 3
+            }
+          ],
+          status: new Date(oe.commence_time) > new Date() ? 'upcoming' : 'completed'
+        } as IEvent;
+
+        let event = await Event.findOne({ externalId: oe.id });
+        if (!event) {
+          event = await Event.create(eventData);
+        } else {
+          event.set(eventData);
+          await event.save();
+        }
+        events.push(event);
+      }
+      return events;
+    } catch (err) {
+      console.error('Error fetching odds for', sport.organization, err);
+      return [];
+    }
+  }
+}

--- a/frontend/src/stores/capperStore.ts
+++ b/frontend/src/stores/capperStore.ts
@@ -1,0 +1,37 @@
+import { create } from 'zustand';
+import type { User, Pick } from '@clout/shared';
+import { userService, pickService } from '../services/api';
+
+export interface CapperData {
+  capper: User;
+  followers: User[];
+  picks: Pick[];
+}
+
+interface CapperStoreState {
+  cappers: Map<string, CapperData>;
+  loadCapperData: (capperId: string) => Promise<void>;
+}
+
+export const useCapperStore = create<CapperStoreState>((set, get) => ({
+  cappers: new Map(),
+  async loadCapperData(capperId: string) {
+    const [capperRes, followersRes, picksRes] = await Promise.all([
+      userService.getProfile(capperId),
+      userService.getFollowers(capperId),
+      pickService.getCapperPicks(capperId)
+    ]);
+
+    const data: CapperData = {
+      capper: capperRes.data.data!,
+      followers: followersRes.data.data || [],
+      picks: picksRes.data.data || []
+    };
+
+    set(state => {
+      const map = new Map(state.cappers);
+      map.set(capperId, data);
+      return { cappers: map };
+    });
+  }
+}));

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -16,7 +16,17 @@ export interface FightEvent {
   eventName: string;
   date: string;
   fighters: string[];
-  organization: 'UFC' | 'Bellator' | 'ONE' | 'PFL' | 'Boxing' | 'Other';
+  organization:
+    | 'UFC'
+    | 'Bellator'
+    | 'ONE'
+    | 'PFL'
+    | 'Boxing'
+    | 'NFL'
+    | 'NBA'
+    | 'MLB'
+    | 'Soccer'
+    | 'Other';
 }
 
 // Prediction types


### PR DESCRIPTION
## Summary
- support more sports in shared and backend models
- update pick validation for expanded organizations
- add service to fetch data for multiple sports
- store capper/follower data in new frontend store
- provide Jest setup file

## Testing
- `npm test` *(fails: Test suite failed to run)*

------
https://chatgpt.com/codex/tasks/task_e_6888dc34a6908321ba3ade6d36cd9ff5